### PR TITLE
Add metric information about project

### DIFF
--- a/sustain-example.md
+++ b/sustain-example.md
@@ -30,6 +30,16 @@ The following individuals are maintainers and have the skills, know-how, and acc
   * GitHub: @sustainmd-example
   * Keybase/PGP: `B201D628F1302A5E3815B7CEBB28B310B9F90A33`
 
+## Metrics
+"You cannot improve what you do not measure." 
+Public metrics about this project are avaible at these locations:
+
+* https://example.com/metrics-dashboard
+* https://www.openhub.net/p/example-project
+* https://libraries.io/example-tracker/example-project
+
+
+
 ---
 
 If you would like to improve this please fork it here: https://github.com/sustainers/sustain.md


### PR DESCRIPTION
This pull request is to add a section to the `SUSTAIN.md` that links to sources of metrics.

Several LF and Apache projects have metrics dashboards. E.g.,
- https://cloudfoundry.biterg.io/app/kibana#/dashboard/Overview
- https://kibble.apache.org/

_Rationale:_ A sustainable project is self reflective and can leverage metrics to identify trends, measure impact of interventions, and backup claims of sustainability with data. Providing such metrics is not an easy task, but it demonstrates maturity.

Feedback please @jdorfman 